### PR TITLE
fix missing header file

### DIFF
--- a/sample/src/main/java/com/handmark/pulltorefresh/samples/PullToRefreshScrollViewActivity.java
+++ b/sample/src/main/java/com/handmark/pulltorefresh/samples/PullToRefreshScrollViewActivity.java
@@ -24,7 +24,6 @@ import com.handmark.pulltorefresh.library.PullToRefreshBase;
 import com.handmark.pulltorefresh.library.PullToRefreshBase.OnRefreshListener;
 import com.handmark.pulltorefresh.library.PullToRefreshScrollView;
 import com.handmark.pulltorefresh.samples.loadinglayout.JingDongHeaderLayout;
-import com.handmark.pulltorefresh.samples.loadinglayout.JingDongHeaderLayout_saves;
 
 public final class PullToRefreshScrollViewActivity extends Activity {
 


### PR DESCRIPTION
delete import com.handmark.pulltorefresh.samples.loadinglayout.JingDongHeaderLayout_saves;
删除了一个已经不存大的导入，否则下载后导入会报错
